### PR TITLE
Prompt for the express scaffolding type

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -15,6 +15,29 @@ function ExpressGenerator(args, options, config) {
 
 util.inherits(ExpressGenerator, yeoman.generators.NamedBase);
 
+ExpressGenerator.prototype.promptType = function promptType() {
+  // Short circuit if an option was explicitly specified
+  if (this.options.mvc || this.options.basic) {
+    return true;
+  }
+
+  var done = this.async();
+  var prompt = [{
+    type: 'list',
+    name: 'type',
+    message: 'Select a version to install:',
+    choices: [
+      'Basic',
+      'MVC'
+    ]
+  }];
+
+  this.prompt(prompt, function (responses) {
+    this.options.mvc = responses.type === 'MVC';
+    done();
+  }.bind(this));
+};
+
 ExpressGenerator.prototype.buildEnv = function buildEnv() {
   this.sourceRoot(path.join(__dirname, 'templates', 'common'));
   this.directory('.', '.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-express",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A nodejs express generator for Yeoman",
   "keywords": [
     "yeoman-generator",

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -37,6 +37,7 @@ describe('express generator', function () {
       'views/index.jade',
       'views/layout.jade'
     ];
+    this.app.options.basic = true;
     this.app.options['skip-install'] = true;
     this.app.run({}, function () {
       helpers.assertFiles(expected);


### PR DESCRIPTION
Prompt the user for which type of express app they would like to create.  Default is basic.  If a type is specified as a CLI option, the prompt is skipped.  Test updated accordingly.
