### PR TITLE
add time-grunt and load-grunt-tasks

### DIFF
--- a/app/templates/basic/Gruntfile.js
+++ b/app/templates/basic/Gruntfile.js
@@ -3,6 +3,11 @@
 var request = require('request');
 
 module.exports = function (grunt) {
+  // show elapsed time at the end
+  require('time-grunt')(grunt);
+  // load all grunt tasks
+  require('load-grunt-tasks')(grunt);
+
   var reloadPort = 35729, files;
 
   grunt.initConfig({
@@ -63,9 +68,6 @@ module.exports = function (grunt) {
         });
     }, 500);
   });
-
-  grunt.loadNpmTasks('grunt-develop');
-  grunt.loadNpmTasks('grunt-contrib-watch');
 
   grunt.registerTask('default', ['develop', 'watch']);
 };

--- a/app/templates/basic/package.json
+++ b/app/templates/basic/package.json
@@ -13,6 +13,8 @@
     "grunt": "~0.4.1",
     "grunt-develop": "~0.1.1",
     "grunt-contrib-watch": "~0.4.4",
-    "request": "~2.22.0"
+    "request": "~2.22.0",
+    "time-grunt": "~0.1.1",
+    "load-grunt-tasks": "~0.2.0"
   }
 }


### PR DESCRIPTION
[time-grunt](https://github.com/sindresorhus/time-grunt) displays the elapsed execution time of grunt tasks and [load-grunt-tasks](https://github.com/sindresorhus/load-grunt-tasks) loads all the grunt tasks for you so you don't have to load each one manually. We're using it in [generator-webapp](https://github.com/yeoman/generator-webapp/blob/master/app/templates/Gruntfile.js#L11-L12).
