### PR TITLE
fix: static-favicon 2.0.1 doesn't exist

### DIFF
--- a/app/templates/basic/package.json
+++ b/app/templates/basic/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "express": "~4.4.5",
-    "static-favicon": "~2.0.1",
+    "serve-favicon": "~2.0.1",
     "morgan": "~1.1.1",
     "cookie-parser": "~1.3.2",
     "body-parser": "~1.4.3",


### PR DESCRIPTION
static-favicon module has been replaced by serve-favicon
