### PR TITLE
Fix error handling in CoffeeScript MVC's express.coffee

### DIFF
--- a/app/templates/mvc-coffee/config/express.coffee
+++ b/app/templates/mvc-coffee/config/express.coffee
@@ -29,22 +29,29 @@ module.exports = (app, config) ->
     if file.indexOf('.coffee') >= 0
       require(controllersPath + '/' + file)(app)
 
+  # catch 404 and forward to error handler
   app.use (req, res, next) ->
     err = new Error 'Not Found'
     err.status = 404
     next err
 
-  if app.get 'env' == 'development'
-    app.use (err, req, res) ->
+  # error handlers
+
+  # development error handler
+  # will print stacktrace
+  if app.get('env') == 'development'
+    app.use (err, req, res, next) ->
       res.status err.status || 500
       res.render 'error',
-        message: err.message,
-        error: err,
+        message: err.message
+        error: err
         title: 'error'
 
-  app.use (err, req, res) ->
+  # production error handler
+  # no stacktraces leaked to user
+  app.use (err, req, res, next) ->
     res.status err.status || 500
     res.render 'error',
-      message: err.message,
-      error: {},
+      message: err.message
+      error: {}
       title: 'error'


### PR DESCRIPTION
The error handlers were defined improperly, leading them to be ignored
on 404's and the like. I copied the code from the app.coffee in the
basic structure to replace it.
