### PR TITLE
Added EOL check in require loop

### DIFF
--- a/app/templates/mvc-coffee/app.coffee
+++ b/app/templates/mvc-coffee/app.coffee
@@ -11,7 +11,7 @@ db.on 'error', ->
 
 modelsPath = __dirname + '/app/models'
 fs.readdirSync(modelsPath).forEach (file) ->
-  if  file.indexOf('.coffee') >= 0
+  if file.match(/\.coffee$/) >= 0
     require modelsPath + '/' + file
 <% } %>
 app = express()

--- a/app/templates/mvc-coffee/config/express.coffee
+++ b/app/templates/mvc-coffee/config/express.coffee
@@ -26,7 +26,7 @@ module.exports = (app, config) ->
 
   controllersPath = path.join __dirname, '../app/controllers'
   fs.readdirSync(controllersPath).forEach (file) ->
-    if file.indexOf('.coffee') >= 0
+    if file.match(/\.coffee$/) >= 0
       require(controllersPath + '/' + file)(app)
 
   # catch 404 and forward to error handler

--- a/app/templates/mvc/app.js
+++ b/app/templates/mvc/app.js
@@ -12,7 +12,7 @@ db.on('error', function () {
 
 var modelsPath = __dirname + '/app/models';
 fs.readdirSync(modelsPath).forEach(function (file) {
-  if (file.indexOf('.js') >= 0) {
+  if (file.match(/\.js$/) >= 0) {
     require(modelsPath + '/' + file);
   }
 });<% } %>

--- a/app/templates/mvc/config/express.js
+++ b/app/templates/mvc/config/express.js
@@ -26,7 +26,7 @@ module.exports = function(app, config) {
 
   var controllersPath = path.join(__dirname, '../app/controllers');
   fs.readdirSync(controllersPath).forEach(function (file) {
-    if (file.indexOf('.js') >= 0) {
+    if (file.match(/\.js$/) >= 0) {
       require(controllersPath + '/' + file)(app);
     }
   });


### PR DESCRIPTION
The standard loop to require files checked for .(js|coffee), but that included swapfiles.

```
/home/modin/code/project/app/models/.article.js.swp:1
(function (exports, require, module, __filename, __dirname) { b0VIM 7.4
                                                                    ^^^
SyntaxError: Unexpected number
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /home/modin/code/project/app.js:15:5
    at Array.forEach (native)
    at Object.<anonymous> (/home/modin/code/project/app.js:13:28)
    at Module._compile (module.js:456:26)
>> application exited with code 8
```

I changed the loop so that the file extension has to be at the very end of the filename to be required.
