### PR TITLE
fixed callback error handling

### DIFF
--- a/app/templates/mvc/config/express.js
+++ b/app/templates/mvc/config/express.js
@@ -35,7 +35,7 @@ module.exports = function(app, config) {
   });
 
   if(app.get('env') === 'development'){
-    app.use(function (err, req, res) {
+    app.use(function (err, req, res, next) {
       res.status(err.status || 500);
       res.render('error', {
         message: err.message,
@@ -45,7 +45,7 @@ module.exports = function(app, config) {
     });
   }
 
-  app.use(function (err, req, res) {
+  app.use(function (err, req, res, next) {
     res.status(err.status || 500);
     res.render('error', {
       message: err.message,


### PR DESCRIPTION
I recieved a `Error: Not Found at Layer.handle.......( a lot of stuff )` when i tried to invoke a 404 error page on MVC configuration.

the callback parameter on basic configuration is there, and MVC-Coffee configuration was added on this commit https://github.com/petecoop/generator-express/commit/172af2478d9bcb6d86000217d42f8666b13550c6.

thanks
