### PR TITLE
fixed swig error template - formatting output

### DIFF
--- a/app/templates/views/swig/error.swig
+++ b/app/templates/views/swig/error.swig
@@ -1,7 +1,7 @@
 {% extends 'layout.swig' %}
 
 {% block content %}
-  {{ message }}
-  {{ error.status }}
-  {{ error.stack }}
+  <h1>{{ message }}</h1>
+  <h2>{{ error.status }}</h2>
+  <pre>{{ error.stack }}</pre>
 {% endblock %}


### PR DESCRIPTION
Refactored swig error template so that it is properly formatted when display error.