### PR TITLE
fix for new gulp-ruby-sass version 1.0.0-alpha

### DIFF
--- a/app/templates/extras/basic-shared/gulpfile.js
+++ b/app/templates/extras/basic-shared/gulpfile.js
@@ -7,8 +7,7 @@ var gulp = require('gulp'),
   stylus = require('gulp-stylus')<% } %>;
 <% if(options.cssPreprocessor == 'sass'){ %>
 gulp.task('sass', function () {
-  return gulp.src('./public/css/*.scss')
-    .pipe(sass())
+  return sass('./public/css/*.scss')
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });

--- a/app/templates/extras/mvc-shared/gulpfile.js
+++ b/app/templates/extras/mvc-shared/gulpfile.js
@@ -7,8 +7,7 @@ var gulp = require('gulp'),
   stylus = require('gulp-stylus')<% } %>;
 <% if(options.cssPreprocessor == 'sass'){ %>
 gulp.task('sass', function () {
-  return gulp.src('./public/css/*.scss')
-    .pipe(sass())
+  return sass('./public/css/*.scss')
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });


### PR DESCRIPTION
API changed in new version. 

Read http://stackoverflow.com/questions/28140012/gulp-typeerror-arguments-to-path-join-must-be-strings for more information.