### PR TITLE
gulp-ruby-sass doesn't support globals anymore

### DIFF
--- a/app/templates/extras/basic-shared/gulpfile.js
+++ b/app/templates/extras/basic-shared/gulpfile.js
@@ -7,7 +7,7 @@ var gulp = require('gulp'),
   stylus = require('gulp-stylus')<% } %>;
 <% if(options.cssPreprocessor == 'sass'){ %>
 gulp.task('sass', function () {
-  return sass('./public/css/*.scss')
+  return sass('./public/css/')
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });

--- a/app/templates/extras/mvc-shared/gulpfile.js
+++ b/app/templates/extras/mvc-shared/gulpfile.js
@@ -7,7 +7,7 @@ var gulp = require('gulp'),
   stylus = require('gulp-stylus')<% } %>;
 <% if(options.cssPreprocessor == 'sass'){ %>
 gulp.task('sass', function () {
-  return sass('./public/css/*.scss')
+  return sass('./public/css/')
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });


### PR DESCRIPTION
gulp-ruby-sass dropped support for globals. I don't know if this is the best solution, but it works.
It compiles the whole /css folder, seems right for me.

For more informations: https://github.com/sindresorhus/gulp-ruby-sass/issues/194

*Thanks,
Atrox*