### PR TITLE
Error handling for sass/less/stylus so Gulp doesn't crash

### DIFF
--- a/.dependencies.json
+++ b/.dependencies.json
@@ -37,6 +37,6 @@
   "gulp-stylus": "~2.0.0",
   "gulp-nodemon": "~2.0.2",
   "gulp-livereload": "~3.8.0",
-  "gulp-plumber": "~1.0.0"
+  "gulp-plumber": "~1.0.0",
   "coffee-script": "~1.9.1"
 }

--- a/.dependencies.json
+++ b/.dependencies.json
@@ -37,5 +37,6 @@
   "gulp-stylus": "~2.0.0",
   "gulp-nodemon": "~2.0.2",
   "gulp-livereload": "~3.8.0",
+  "gulp-plumber": "~1.0.0"
   "coffee-script": "~1.9.1"
 }

--- a/app/templates/basic-shared/package.json
+++ b/app/templates/basic-shared/package.json
@@ -36,6 +36,7 @@
     "gulp-less": "~3.0.1"<% } %><% if(options.cssPreprocessor == 'stylus'){ %>,
     "gulp-stylus": "~2.0.0"<% } %>,
     "gulp-nodemon": "~2.0.2",
-    "gulp-livereload": "~3.8.0"<% } %>
+    "gulp-livereload": "~3.8.0",
+    "gulp-plumber": "~1.0.0"<% } %>
   }
 }

--- a/app/templates/extras/basic-shared/gulpfile.js
+++ b/app/templates/extras/basic-shared/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
   nodemon = require('gulp-nodemon'),
+  plumber = require('gulp-plumber'),
   livereload = require('gulp-livereload')<% if(options.cssPreprocessor == 'sass'){ %>,
   sass = require('gulp-ruby-sass')<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>,
   sass = require('gulp-sass')<% } %><% if(options.cssPreprocessor == 'less'){ %>,
@@ -17,8 +18,8 @@ gulp.task('watch', function() {
 });<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>
 gulp.task('sass', function () {
   gulp.src('./public/css/*.scss')
+    .pipe(plumber())
     .pipe(sass())
-    .on('error', function(err){ console.log(err.message); })
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });
@@ -28,8 +29,8 @@ gulp.task('watch', function() {
 });<% } %><% if(options.cssPreprocessor == 'less'){ %>
 gulp.task('less', function () {
   gulp.src('./public/css/*.less')
+    .pipe(plumber())
     .pipe(less())
-    .on('error', function(err){ console.log(err.message); })
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });
@@ -39,8 +40,8 @@ gulp.task('watch', function() {
 });<% } %><% if(options.cssPreprocessor == 'stylus'){ %>
 gulp.task('stylus', function () {
   gulp.src('./public/css/*.styl')
+    .pipe(plumber())
     .pipe(stylus())
-    .on('error', function(err){ console.log(err.message); })
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });

--- a/app/templates/extras/basic-shared/gulpfile.js
+++ b/app/templates/extras/basic-shared/gulpfile.js
@@ -18,6 +18,7 @@ gulp.task('watch', function() {
 gulp.task('sass', function () {
   gulp.src('./public/css/*.scss')
     .pipe(sass())
+    .on('error', function(err){ console.log(err.message); })
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });
@@ -28,6 +29,7 @@ gulp.task('watch', function() {
 gulp.task('less', function () {
   gulp.src('./public/css/*.less')
     .pipe(less())
+    .on('error', function(err){ console.log(err.message); })
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });
@@ -38,6 +40,7 @@ gulp.task('watch', function() {
 gulp.task('stylus', function () {
   gulp.src('./public/css/*.styl')
     .pipe(stylus())
+    .on('error', function(err){ console.log(err.message); })
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });

--- a/app/templates/extras/mvc-shared/gulpfile.js
+++ b/app/templates/extras/mvc-shared/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
   nodemon = require('gulp-nodemon'),
+  plumber = require('gulp-plumber'),
   livereload = require('gulp-livereload')<% if(options.cssPreprocessor == 'sass'){ %>,
   sass = require('gulp-ruby-sass')<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>,
   sass = require('gulp-sass')<% } %><% if(options.cssPreprocessor == 'less'){ %>,

--- a/app/templates/extras/mvc-shared/gulpfile.js
+++ b/app/templates/extras/mvc-shared/gulpfile.js
@@ -18,6 +18,7 @@ gulp.task('watch', function() {
 });<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>
 gulp.task('sass', function () {
   gulp.src('./public/css/*.scss')
+    .pipe(plumber())
     .pipe(sass())
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
@@ -28,6 +29,7 @@ gulp.task('watch', function() {
 });<% } %><% if(options.cssPreprocessor == 'less'){ %>
 gulp.task('less', function () {
   gulp.src('./public/css/*.less')
+    .pipe(plumber())
     .pipe(less())
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
@@ -38,6 +40,7 @@ gulp.task('watch', function() {
 });<% } %><% if(options.cssPreprocessor == 'stylus'){ %>
 gulp.task('stylus', function () {
   gulp.src('./public/css/*.styl')
+    .pipe(plumber())
     .pipe(stylus())
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());

--- a/app/templates/mvc-shared/package.json
+++ b/app/templates/mvc-shared/package.json
@@ -47,6 +47,7 @@
     "gulp-less": "~3.0.1"<% } %><% if(options.cssPreprocessor == 'stylus'){ %>,
     "gulp-stylus": "~2.0.0"<% } %>,
     "gulp-nodemon": "~2.0.2",
-    "gulp-livereload": "~3.8.0"<% } %>
+    "gulp-livereload": "~3.8.0",
+    "gulp-plumber": "~1.0.0"<% } %>
   }
 }


### PR DESCRIPTION
The error will now be logged instead of crashing Gulp when there's an error in sass/less/stylus.