### PR TITLE
Updating Express configuration with swig view engine

### DIFF
--- a/app/templates/mvc-coffee/config/express.coffee
+++ b/app/templates/mvc-coffee/config/express.coffee
@@ -23,6 +23,11 @@ module.exports = (app, config) -><% if(options.viewEngine == 'swig'){ %>
   env = process.env.NODE_ENV || 'development'
   app.locals.ENV = env;
   app.locals.ENV_DEVELOPMENT = env == 'development'
+  <% if(options.viewEngine == 'swig'){ %>
+  	if app.locals.ENV == 'development'
+  		app.set 'view cache', false
+  		swig.setDefaults cache: false
+  <% } %>
 
   # app.use(favicon(config.root + '/public/img/favicon.ico'));
   app.use logger 'dev'

--- a/app/templates/mvc/config/express.js
+++ b/app/templates/mvc/config/express.js
@@ -23,6 +23,12 @@ module.exports = function(app, config) {<% if(options.viewEngine == 'swig'){ %>
   var env = process.env.NODE_ENV || 'development';
   app.locals.ENV = env;
   app.locals.ENV_DEVELOPMENT = env == 'development';
+  {<% if(options.viewEngine == 'swig'){ %>
+    if(app.locals.ENV == 'development'){
+      app.set('view cache', false);
+	    swig.setDefaults({ cache: false });
+  }
+  <% } %>
 
   // app.use(favicon(config.root + '/public/img/favicon.ico'));
   app.use(logger('dev'));

--- a/app/templates/mvc/config/express.js
+++ b/app/templates/mvc/config/express.js
@@ -23,7 +23,7 @@ module.exports = function(app, config) {<% if(options.viewEngine == 'swig'){ %>
   var env = process.env.NODE_ENV || 'development';
   app.locals.ENV = env;
   app.locals.ENV_DEVELOPMENT = env == 'development';
-  {<% if(options.viewEngine == 'swig'){ %>
+  <% if(options.viewEngine == 'swig'){ %>
     if(app.locals.ENV == 'development'){
       app.set('view cache', false);
 	    swig.setDefaults({ cache: false });


### PR DESCRIPTION
Livereload wouldn't work show changes made if using the swig template engine due to caching. A solution I found is to remove the caching if the environment is set to development.