### PR TITLE
Corrects an omission in seqelize-model-index.js

### DIFF
--- a/app/templates/extras/mvc/sequelize-model-index.js
+++ b/app/templates/extras/mvc/sequelize-model-index.js
@@ -4,9 +4,9 @@ var fs = require('fs'),
   config = require('../../config/config'),
   db = {};
 
-var sequelize = new Sequelize(config.db<% if (options.database == 'sqlite') %>, {
+var sequelize = new Sequelize(config.db<% if (options.database == 'sqlite') { %>, {
   storage: config.storage
-});
+}<% } %>);
 
 fs.readdirSync(__dirname).filter(function (file) {
   return (file.indexOf('.') !== 0) && (file !== 'index.js');


### PR DESCRIPTION
This fixes an apparent omission of the opening and closing curly braces in an if block in templates/extras/mvc/sequelize-model-index.js

If it's not a bug, please tell me why (I'm not very familiar with EJS, so it's possible that it only looks like a problem to me :-)