### PR TITLE
Use glob because gulp-ruby-sass does not support directory sources (anymore)

### DIFF
--- a/app/templates/extras/basic-shared/gulpfile.js
+++ b/app/templates/extras/basic-shared/gulpfile.js
@@ -8,7 +8,7 @@ var gulp = require('gulp'),
   stylus = require('gulp-stylus')<% } %>;
 <% if(options.cssPreprocessor == 'sass'){ %>
 gulp.task('sass', function () {
-  return sass('./public/css/')
+  return sass('./public/css/**/*.scss')
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });

--- a/app/templates/extras/mvc-shared/gulpfile.js
+++ b/app/templates/extras/mvc-shared/gulpfile.js
@@ -8,7 +8,7 @@ var gulp = require('gulp'),
   stylus = require('gulp-stylus')<% } %>;
 <% if(options.cssPreprocessor == 'sass'){ %>
 gulp.task('sass', function () {
-  return sass('./public/css/')
+  return sass('./public/css/**/*.scss')
     .pipe(gulp.dest('./public/css'))
     .pipe(livereload());
 });


### PR DESCRIPTION
[gulp-ruby-sass](https://github.com/sindresorhus/gulp-ruby-sass) as [of 2.0.0](https://github.com/sindresorhus/gulp-ruby-sass/commit/756ed6f5e0b59aa735d2302318dde685615e60bb)(?) does not support directories anymore, which results in no files getting compiled at all.  
Proposed fix: use a glob like the docs say.