### PR TITLE
sorting package.json deps and adding fields

### DIFF
--- a/app/templates/basic-shared/package.json
+++ b/app/templates/basic-shared/package.json
@@ -1,22 +1,31 @@
 {
   "name": "<%= slugify(appname) %>",
   "version": "0.0.1",
+  "description": "",
+  "keywords": "",
+  "repository": "",
+  "homepage": "",
+  "bugs": "",
+  "license": "MIT",
+  "author": "",
+  "contributors": "",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"
   },
+  "main": "app.js",
   "dependencies": {
-    "express": "^4.13.3",
-    "serve-favicon": "^2.3.0",
-    "morgan": "^1.6.1",
-    "cookie-parser": "^1.3.3",
-    "body-parser": "^1.13.3"<% if(options.viewEngine == 'jade'){ %>,
-    "jade": "^1.11.0"<% } %><% if(options.viewEngine == 'ejs'){ %>,
-    "ejs": "^2.3.1"<% } %><% if(options.viewEngine == 'swig'){ %>,
-    "swig": "^1.4.2"<% } %><% if(options.viewEngine == 'handlebars'){ %>,
-    "express-handlebars": "^3.0.0"<% } %><% if(options.viewEngine == 'marko'){ %>,
-    "marko": "^3.4.2"<% } %><% if (options.viewEngine == 'nunjucks'){ %>,
-    "nunjucks": "^2.0.0"<% } %>
+    "body-parser": "^1.13.3",
+    "cookie-parser": "^1.3.3"<% if(options.viewEngine == 'ejs'){ %>,
+    "ejs": "^2.3.1"<% } %>,
+    "express": "^4.13.3"<% if(options.viewEngine == 'handlebars'){ %>,
+    "express-handlebars": "^3.0.0"<% } %><% if(options.viewEngine == 'jade'){ %>,
+    "jade": "^1.11.0"<% } %><% if(options.viewEngine == 'marko'){ %>,
+    "marko": "^3.4.2"<% } %>,
+    "morgan": "^1.6.1"<% if (options.viewEngine == 'nunjucks'){ %>,
+    "nunjucks": "^2.0.0",
+    "serve-favicon": "^2.3.0"<% } %><% if(options.viewEngine == 'swig'){ %>,
+    "swig": "^1.4.2"<% } %>
   },
   "devDependencies": {<% if(options.coffee){ %>
     "coffee-script": "^1.9.1",<% } %><% if(options.buildTool == 'grunt'){ %>
@@ -26,10 +35,7 @@
     "grunt-sass": "^1.0.0"<% } %><% if(options.cssPreprocessor == 'less'){ %>,
     "grunt-contrib-less": "^1.0.0"<% } %><% if(options.cssPreprocessor == 'stylus'){ %>,
     "grunt-contrib-stylus": "^1.0.0"<% } %>,
-    "grunt-contrib-watch": "^1.0.0",
-    "request": "^2.60.0",
-    "time-grunt": "^1.2.1",
-    "load-grunt-tasks": "^3.2.0"<% } %><% if(options.buildTool == 'gulp'){ %>
+    "grunt-contrib-watch": "^1.0.0"<% } %><% if(options.buildTool == 'gulp'){ %>
     "gulp": "^3.9.0"<% if(options.cssPreprocessor == 'sass'){ %>,
     "gulp-ruby-sass": "^2.0.1"<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>,
     "gulp-sass": "^2.0.4"<% } %><% if(options.cssPreprocessor == 'less'){ %>,
@@ -37,6 +43,9 @@
     "gulp-stylus": "^2.0.0"<% } %>,
     "gulp-nodemon": "^2.0.2",
     "gulp-livereload": "^3.8.0",
-    "gulp-plumber": "^1.0.0"<% } %>
+    "gulp-plumber": "^1.0.0"<% } %><% if(options.buildTool == 'grunt'){ %>,
+    "load-grunt-tasks": "^3.2.0"<% } %>,
+    "request": "^2.60.0",
+    "time-grunt": "^1.2.1"
   }
 }

--- a/app/templates/mvc-shared/package.json
+++ b/app/templates/mvc-shared/package.json
@@ -1,34 +1,41 @@
 {
   "name": "<%= slugify(appname) %>",
   "version": "0.0.1",
+  "description": "",
+  "keywords": "",
+  "repository": "",
+  "homepage": "",
+  "bugs": "",
+  "license": "MIT",
+  "author": "",
+  "contributors": "",
   "private": true,
   "scripts": {
     "start": "node app.js"
   },
+  "main": "app.js",
   "dependencies": {
-    "express": "^4.13.3",
-    "serve-favicon": "^2.3.0",
-    "morgan": "^1.6.1",
-    "cookie-parser": "^1.3.3",
     "body-parser": "^1.13.3",
-    "compression": "^1.5.2",
+    "cookie-parser": "^1.3.3",
+    "compression": "^1.5.2"<% if(options.viewEngine == 'ejs'){ %>,
+    "ejs": "^2.3.1"<% } %>,
+    "express": "^4.13.3"<% if(options.viewEngine == 'handlebars'){ %>,
+    "express-handlebars": "^3.0.0"<% } %>,
+    "glob": "^6.0.4"<% if(options.viewEngine == 'jade'){ %>,
+    "jade": "^1.11.0"<% } %><% if(options.viewEngine == 'marko'){ %>,
+    "marko": "^3.4.2"<% } %>,
     "method-override": "^2.3.0",
-    "glob": "^6.0.4"<% if(options.database == 'mongodb'){ %>,
+    "morgan": "^1.6.1"<% if(options.database == 'mongodb'){ %>,
     "mongoose": "^4.1.2"<% } %><% if(options.database == 'mysql'){ %>,
-    "sequelize": "^3.5.1",
-    "mysql": "^2.8.0"<% } %><% if(options.database == 'postgresql'){ %>,
-    "sequelize": "^3.5.1",
+    "mysql": "^2.8.0"<% } %><% if (options.viewEngine == 'nunjucks'){ %>,
+    "nunjucks": "^2.0.0"<% if(options.database == 'postgresql'){ %>,
     "pg": "^6.0.1",
-    "pg-hstore": "2.3.2"<% } %><% if(options.database == 'sqlite'){ %>,
-    "sequelize": "^3.5.1",
-    "sqlite3": "^3.0.5"<% } %><% if(options.database == 'rethinkdb'){ %>,
-    "thinky": "^1.16.6"<% } %><% if(options.viewEngine == 'jade'){ %>,
-    "jade": "^1.11.0"<% } %><% if(options.viewEngine == 'ejs'){ %>,
-    "ejs": "^2.3.1"<% } %><% if(options.viewEngine == 'swig'){ %>,
-    "swig": "^1.4.2"<% } %><% if(options.viewEngine == 'handlebars'){ %>,
-    "express-handlebars": "^3.0.0"<% } %><% if(options.viewEngine == 'marko'){ %>,
-    "marko": "^3.4.2"<% } %><% if (options.viewEngine == 'nunjucks'){ %>,
-    "nunjucks": "^2.0.0"<% } %>
+    "pg-hstore": "2.3.2"<% } %><% if(options.database == 'rethinkdb'){ %>,
+    "thinky": "^1.16.6"<% } %>,
+    "serve-favicon": "^2.3.0"<% } %><% if(options.database == 'postgresql' || options.database == 'mysql' || options.database == 'sqlite'){ %>,
+    "sequelize": "^3.5.1"<% } %><% if(options.database == 'sqlite'){ %>,
+    "sqlite3": "^3.0.5"<% } %><% if(options.viewEngine == 'swig'){ %>,
+    "swig": "^1.4.2"<% } %>
   },
   "devDependencies": {<% if(options.coffee){ %>
     "coffee-script": "^1.9.1",<% } %><% if(options.buildTool == 'grunt'){ %>
@@ -38,10 +45,7 @@
     "grunt-sass": "^1.0.0"<% } %><% if(options.cssPreprocessor == 'less'){ %>,
     "grunt-contrib-less": "^1.0.0"<% } %><% if(options.cssPreprocessor == 'stylus'){ %>,
     "grunt-contrib-stylus": "^1.0.0"<% } %>,
-    "grunt-contrib-watch": "^1.0.0",
-    "request": "^2.60.0",
-    "time-grunt": "^1.2.1",
-    "load-grunt-tasks": "^3.2.0"<% } %><% if(options.buildTool == 'gulp'){ %>
+    "grunt-contrib-watch": "^1.0.0"<% } %><% if(options.buildTool == 'gulp'){ %>
     "gulp": "^3.9.0"<% if(options.cssPreprocessor == 'sass'){ %>,
     "gulp-ruby-sass": "^2.0.1"<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>,
     "gulp-sass": "^2.0.4"<% } %><% if(options.cssPreprocessor == 'less'){ %>,
@@ -49,6 +53,9 @@
     "gulp-stylus": "^2.0.0"<% } %>,
     "gulp-nodemon": "^2.0.2",
     "gulp-livereload": "^3.8.0",
-    "gulp-plumber": "^1.0.0"<% } %>
+    "gulp-plumber": "^1.0.0"<% } %><% if(options.buildTool == 'grunt'){ %>,
+    "load-grunt-tasks": "^3.2.0"<% } %>,
+    "request": "^2.60.0",
+    "time-grunt": "^1.2.1"
   }
 }


### PR DESCRIPTION
When I did `npm install xxxxx --save` it re-sorts the package.json, having the sorted alphabetically helps for re-scaffolding using the generator.

This PR adds the fields which http://package-json-validator.com/ says are missing

For the `license` field I used https://spdx.org/licenses/ and choose the default for GitHub (MIT)
