### PR TITLE
Template/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+before_script:
+  - npm install -g yo
+after_script:
+  - npm run test:generate

--- a/app/index.js
+++ b/app/index.js
@@ -5,6 +5,7 @@ var generators = require('yeoman-generator');
 var glob = require('glob');
 var slugify = require('underscore.string/slugify');
 var mkdirp = require('mkdirp');
+var spawn = require('cross-spawn');
 
 module.exports = generators.Base.extend({
   constructor: function () {
@@ -21,7 +22,7 @@ module.exports = generators.Base.extend({
       if (this.options.createDirectory !== undefined) {
         return true;
       }
-      
+
       var prompt = [{
         type: 'confirm',
         name: 'createDirectory',
@@ -247,7 +248,13 @@ module.exports = generators.Base.extend({
       }
     }
   },
-  install: function () {
-    if(!this.options['skip-install']) this.installDependencies();
+  install: function() {
+    if (!this.options['skip-install']) {
+      return this.installDependencies(function() {
+        return spawn('npm', ['run', 'test:coverage'], {
+          stdio: 'inherit'
+        });
+      });
+    }
   }
 });

--- a/app/templates/basic-shared/package.json
+++ b/app/templates/basic-shared/package.json
@@ -2,10 +2,16 @@
   "name": "<%= slugify(appname) %>",
   "version": "0.0.1",
   "private": true,
+  "main": "app.js",
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "test": "mocha --recursive test",
+    "test:coverage": "nyc npm test",
+    "test:unit": "mocha --recursive test/middleware test/models test/routes",
+    "test:integration": "mocha --recursive test/integration"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "express": "^4.13.3",
     "serve-favicon": "^2.3.0",
     "morgan": "^1.6.1",
@@ -18,7 +24,8 @@
     "marko": "^3.4.2"<% } %><% if (options.viewEngine == 'nunjucks'){ %>,
     "nunjucks": "^2.0.0"<% } %>
   },
-  "devDependencies": {<% if(options.coffee){ %>
+  "devDependencies": {
+    "chai": "^3.5.0"<% if(options.coffee){ %>
     "coffee-script": "^1.9.1",<% } %><% if(options.buildTool == 'grunt'){ %>
     "grunt": "^1.0.1",
     "grunt-develop": "^0.4.0"<% if(options.cssPreprocessor == 'sass'){ %>,
@@ -29,7 +36,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "request": "^2.60.0",
     "time-grunt": "^1.2.1",
-    "load-grunt-tasks": "^3.2.0"<% } %><% if(options.buildTool == 'gulp'){ %>
+    "load-grunt-tasks": "^3.2.0"<% } %><% if(options.buildTool == 'gulp'){ %>,
     "gulp": "^3.9.0"<% if(options.cssPreprocessor == 'sass'){ %>,
     "gulp-ruby-sass": "^2.0.1"<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>,
     "gulp-sass": "^2.0.4"<% } %><% if(options.cssPreprocessor == 'less'){ %>,
@@ -37,6 +44,9 @@
     "gulp-stylus": "^2.0.0"<% } %>,
     "gulp-nodemon": "^2.0.2",
     "gulp-livereload": "^3.8.0",
-    "gulp-plumber": "^1.0.0"<% } %>
+    "gulp-plumber": "^1.0.0"<% } %>,
+    "mocha": "^3.0.2",
+    "nyc": "^8.1.0",
+    "supertest": "^2.0.0"
   }
 }

--- a/app/templates/basic/test/app.js
+++ b/app/templates/basic/test/app.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var app = require('./../');
+
+describe('app', function() {
+  it('should load', function() {
+    expect(app).to.be.a('function');
+  });
+});

--- a/app/templates/basic/test/integration/app.js
+++ b/app/templates/basic/test/integration/app.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var expect = require('chai').expect;
+var supertest = require('supertest');
+
+var app = require('./../../');
+
+describe('/', function() {
+  it('should load', function() {
+    expect(app).to.be.a('function');
+  });
+
+  describe('errors', function() {
+    it('should handle pages which are not found', function(done) {
+      supertest(app)
+        .get('/notexistant')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .end(function(err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res.status).to.equal(404);
+
+          done();
+        });
+    });
+  });
+});

--- a/app/templates/basic/test/integration/user.js
+++ b/app/templates/basic/test/integration/user.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var debug = require('debug')('test:integration:user');
+var expect = require('chai').expect;
+var supertest = require('supertest');
+
+var api = require('./../../');
+
+describe('/users', function() {
+  describe('GET', function() {
+    it('should list users', function(done) {
+      supertest(api)
+        .get('/users')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .end(function(err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res.text).to.equal('respond with a resource');
+
+          done();
+        });
+    });
+  });
+});

--- a/app/templates/basic/test/routes/user.js
+++ b/app/templates/basic/test/routes/user.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var user = require('./../../routes/user');
+
+describe('user routes', function() {
+  it('should load', function() {
+    expect(user).to.be.a('function');
+  });
+});

--- a/app/templates/mvc-shared/app.js
+++ b/app/templates/mvc-shared/app.js
@@ -18,16 +18,18 @@ models.forEach(function (model) {
 });<% } %>
 var app = express();
 
-require('./config/express')(app, config);
+module.exports = require('./config/express')(app, config);
 <% if(options.database == 'mysql' ||
   options.database == 'postgresql' ||
   options.database == 'sqlite'){ %>
 db.sequelize
   .sync()
   .then(function () {
-    app.listen(config.port, function () {
-      console.log('Express server listening on port ' + config.port);
-    });
+    if (!module.parent) {
+      app.listen(config.port, function () {
+        console.log('Express server listening on port ' + config.port);
+      });
+    }
   }).catch(function (e) {
     throw new Error(e);
   });

--- a/app/templates/mvc-shared/package.json
+++ b/app/templates/mvc-shared/package.json
@@ -2,10 +2,16 @@
   "name": "<%= slugify(appname) %>",
   "version": "0.0.1",
   "private": true,
+  "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "NODE_ENV=test mocha --recursive test",
+    "test:coverage": "nyc npm test",
+    "test:unit": "mocha --recursive test/middleware test/models test/routes",
+    "test:integration": "mocha --recursive test/integration"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "express": "^4.13.3",
     "serve-favicon": "^2.3.0",
     "morgan": "^1.6.1",
@@ -30,7 +36,8 @@
     "marko": "^3.4.2"<% } %><% if (options.viewEngine == 'nunjucks'){ %>,
     "nunjucks": "^2.0.0"<% } %>
   },
-  "devDependencies": {<% if(options.coffee){ %>
+  "devDependencies": {
+    "chai": "^3.5.0"<% if(options.coffee){ %>
     "coffee-script": "^1.9.1",<% } %><% if(options.buildTool == 'grunt'){ %>
     "grunt": "^1.0.1",
     "grunt-develop": "^0.4.0"<% if(options.cssPreprocessor == 'sass'){ %>,
@@ -41,7 +48,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "request": "^2.60.0",
     "time-grunt": "^1.2.1",
-    "load-grunt-tasks": "^3.2.0"<% } %><% if(options.buildTool == 'gulp'){ %>
+    "load-grunt-tasks": "^3.2.0"<% } %><% if(options.buildTool == 'gulp'){ %>,
     "gulp": "^3.9.0"<% if(options.cssPreprocessor == 'sass'){ %>,
     "gulp-ruby-sass": "^2.0.1"<% } %><% if(options.cssPreprocessor == 'node-sass'){ %>,
     "gulp-sass": "^2.0.4"<% } %><% if(options.cssPreprocessor == 'less'){ %>,
@@ -49,6 +56,9 @@
     "gulp-stylus": "^2.0.0"<% } %>,
     "gulp-nodemon": "^2.0.2",
     "gulp-livereload": "^3.8.0",
-    "gulp-plumber": "^1.0.0"<% } %>
+    "gulp-plumber": "^1.0.0"<% } %>,
+    "mocha": "^3.0.2",
+    "nyc": "^8.1.0",
+    "supertest": "^2.0.0"
   }
 }

--- a/app/templates/mvc/config/express.js
+++ b/app/templates/mvc/config/express.js
@@ -86,4 +86,5 @@ module.exports = function(app, config) {
       });<% } %>
   });
 
+  return app;
 };

--- a/app/templates/mvc/test/app.js
+++ b/app/templates/mvc/test/app.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var app = require('../');
+
+describe('app', function() {
+  it('should load', function() {
+    expect(app).to.be.a('function');
+  });
+});

--- a/app/templates/mvc/test/app/config/config.js
+++ b/app/templates/mvc/test/app/config/config.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var config = require('../../../config/config');
+
+describe('config', function() {
+  it('should load', function() {
+    expect(process.env.NODE_ENV).to.eql('test');
+
+    expect(config).to.eql({
+      root: config.root,
+      app: {
+        name: '<%= slugify(appname) %>'
+      },
+      port: process.env.PORT || 3000,
+      db: 'sqlite://localhost/<%= slugify(appname) %>-test',
+      storage: config.storage
+    });
+  });
+});

--- a/app/templates/mvc/test/app/config/express.js
+++ b/app/templates/mvc/test/app/config/express.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var expect = require('chai').expect;
+var express = require('express');
+var configure = require('../../../config/express');
+
+describe('configure express', function() {
+  it('should load', function() {
+    expect(configure).to.be.a('function');
+  });
+
+  it('should return the app', function() {
+    var app = express();
+
+    expect(configure(app, {})).to.eql(app);
+  });
+});

--- a/app/templates/mvc/test/app/controllers/home.js
+++ b/app/templates/mvc/test/app/controllers/home.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var home = require('../../../app/controllers/home');
+
+describe('home routes', function() {
+  it('should load', function() {
+    expect(home).to.be.a('function');
+  });
+});

--- a/app/templates/mvc/test/app/models/article.js
+++ b/app/templates/mvc/test/app/models/article.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var article = require('../../../app/models/article');
+
+describe('article', function() {
+  it('should load', function() {
+    expect(article).to.be.a('function');
+  });
+});

--- a/app/templates/mvc/test/app/models/index.js
+++ b/app/templates/mvc/test/app/models/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var model = require('../../../app/models/index');
+
+describe('model', function() {
+  it('should load', function() {
+    expect(model).to.be.a('object');
+    expect(model.sequelize).to.be.a('object');
+    expect(model.sequelize.models.Article).to.be.a('object');
+  });
+});

--- a/app/templates/mvc/test/integration/service.js
+++ b/app/templates/mvc/test/integration/service.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var expect = require('chai').expect;
+var supertest = require('supertest');
+
+var app = require('../../');
+
+describe('/', function() {
+  it('should load', function() {
+    expect(app).to.be.a('function');
+  });
+
+  describe('render', function() {
+    it('should render index', function(done) {
+      supertest(app)
+        .get('/')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .end(function(err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res.status).to.equal(200);
+          expect(res.text).to.include('doctype');
+          expect(res.text).to.include('<title>Generator-Express MVC</title>');
+
+          done();
+        });
+    });
+  });
+
+  describe('errors', function() {
+    it('should handle pages which are not found', function(done) {
+      supertest(app)
+        .get('/notexistant')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .end(function(err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res.status).to.equal(404);
+
+          done();
+        });
+    });
+  });
+});

--- a/app/templates/shared/_.gitignore
+++ b/app/templates/shared/_.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 public/components
+.nyc_output
 .sass-cache<% if(options.viewEngine == 'marko'){ %>
 *.marko.js<% } %>

--- a/package.json
+++ b/package.json
@@ -27,9 +27,13 @@
     "url": "https://github.com/petecoop/generator-express.git"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "test:generate": "npm link && npm run test:generate:basic && npm run test:generate:mvc",
+    "test:generate:basic": "mkdir temp; cd temp && yo express --createDirectory true --dirname one --basic true --viewEngine handlebars --cssPreprocessor None --buildTool gulp",
+    "test:generate:mvc": "mkdir temp; cd temp && yo express --createDirectory true --dirname two --mvc true --viewEngine handlebars --cssPreprocessor None --database sqlite --buildTool gulp"
   },
   "dependencies": {
+    "cross-spawn": "^4.0.2",
     "glob": "^7.0.0",
     "mkdirp": "^0.5.0",
     "underscore.string": "^3.0.3",


### PR DESCRIPTION
Hi @petecoop  I've been using your generator to make small apis. I added test scaffolding to them, and wanted to contribute it back instead of using my own apps to scaffold new apps.

For #159 adding tests for basic js app, and mvc app

Update: I added a test script that generates a basic and an mvc to ensure the tests are passing, you can take a look in the travis output https://travis-ci.org/petecoop/generator-express/jobs/169816687

```
$ npm run test:generate

> generator-express@2.13.0 test:generate ~/generator-express
> npm link && npm run test:generate:basic && npm run test:generate:mvc

/usr/local/lib/node_modules/generator-express -> ~/generator-express

> generator-express@2.13.0 test:generate:basic ~/generator-express
> mkdir temp; cd temp && yo express --createDirectory true --dirname one --basic true --viewEngine handlebars --cssPreprocessor None --buildTool gulp

   create .bowerrc
   create .editorconfig
   create .gitignore
   create bower.json
   create app.js
   create bin/www
   create package.json
   create routes/index.js
   create routes/user.js
   create test/app.js
   create test/integration/app.js
   create test/integration/user.js
   create test/routes/user.js
   create views/error.handlebars
   create views/index.handlebars
   create views/layouts/main.handlebars
   create views/partials/welcome.handlebars
   create gulpfile.js


I'm all done. Running npm install && bower install for you to install the required dependencies. If this fails, try running the command yourself.


npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
\
> fsevents@1.0.14 install ~/generator-express/temp/one/node_modules/gulp-nodemon/node_modules/nodemon/node_modules/chokidar/node_modules/fsevents
> node-pre-gyp install --fallback-to-build

[fsevents] Success: "~/generator-express/temp/one/node_modules/gulp-nodemon/node_modules/nodemon/node_modules/chokidar/node_modules/fsevents/lib/binding/Release/node-v46-darwin-x64/fse.node" already installed
Pass --update-binary to reinstall or --build-from-source to recompile
debug@2.2.0 node_modules/debug
└── ms@0.7.1
...
├── event-stream@3.3.4 (pause-stream@0.0.11, duplexer@0.1.1, stream-combiner@0.0.4, from@0.1.3, map-stream@0.1.0, split@0.3.3, through@2.3.8)
└── nodemon@1.11.0 (ignore-by-default@1.0.1, undefsafe@0.0.3, ps-tree@1.1.0, es6-promise@3.3.1, minimatch@3.0.3, lodash.defaults@3.1.2, touch@1.0.0, update-notifier@0.5.0, chokidar@1.6.1)

nyc@8.3.2 node_modules/nyc

> one@0.0.1 test:coverage ~/generator-express/temp/one
> nyc npm test


> one@0.0.1 test ~/generator-express/temp/one
> mocha --recursive test



  app
    ✓ should load

  /
    ✓ should load
    errors
GET /notexistant 404 37.924 ms - 2848
      ✓ should handle pages which are not found (70ms)

  /users
    GET
GET /users 200 1.518 ms - 23
      ✓ should list users

  user routes
    ✓ should load


  5 passing (89ms)

------------|----------|----------|----------|----------|----------------|
File        |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------|----------|----------|----------|----------|----------------|
All files   |    93.33 |       50 |       60 |    93.33 |                |
 one        |    94.29 |       50 |    66.67 |    94.29 |                |
  app.js    |    94.29 |       50 |    66.67 |    94.29 |          67,68 |
 one/routes |       90 |      100 |       50 |       90 |                |
  index.js  |       80 |      100 |        0 |       80 |              7 |
  user.js   |      100 |      100 |      100 |      100 |                |
------------|----------|----------|----------|----------|----------------|

> generator-express@2.13.0 test:generate:mvc ~/generator-express
> mkdir temp; cd temp && yo express --createDirectory true --dirname two --mvc true --viewEngine handlebars --cssPreprocessor None --database sqlite --buildTool gulp

mkdir: temp: File exists
   create .bowerrc
   create .editorconfig
   create .gitignore
   create bower.json
   create app.js
   create package.json
   create app/controllers/home.js
   create app/models/article.js
   create config/config.js
   create config/express.js
   create test/app.js
   create test/app/config/config.js
   create test/app/config/express.js
   create test/app/controllers/home.js
   create test/app/models/article.js
   create test/app/models/index.js
   create test/integration/service.js
   create app/views/error.handlebars
   create app/views/index.handlebars
   create app/views/layouts/main.handlebars
   create app/views/partials/welcome.handlebars
   create gulpfile.js
   create app/models/index.js


I'm all done. Running npm install && bower install for you to install the required dependencies. If this fails, try running the command yourself.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
-
> sqlite3@3.1.6 install ~/generator-express/temp/two/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

[sqlite3] Success: "~/generator-express/temp/two/node_modules/sqlite3/lib/binding/node-v46-darwin-x64/node_sqlite3.node" is installed via remote

> fsevents@1.0.14 install ~/generator-express/temp/two/node_modules/gulp-nodemon/node_modules/nodemon/node_modules/chokidar/node_modules/fsevents
> node-pre-gyp install --fallback-to-build

[fsevents] Success: "~/generator-express/temp/two/node_modules/gulp-nodemon/node_modules/nodemon/node_modules/chokidar/node_modules/fsevents/lib/binding/Release/node-v46-darwin-x64/fse.node" already installed
Pass --update-binary to reinstall or --build-from-source to recompile
cookie-parser@1.4.3 node_modules/cookie-parser
├── cookie-signature@1.0.6
...
├── event-stream@3.3.4 (pause-stream@0.0.11, duplexer@0.1.1, stream-combiner@0.0.4, from@0.1.3, map-stream@0.1.0, split@0.3.3, through@2.3.8)
└── nodemon@1.11.0 (ignore-by-default@1.0.1, undefsafe@0.0.3, ps-tree@1.1.0, es6-promise@3.3.1, minimatch@3.0.3, lodash.defaults@3.1.2, touch@1.0.0, update-notifier@0.5.0, chokidar@1.6.1)

nyc@8.3.2 node_modules/nyc

> two@0.0.1 test:coverage ~/generator-express/temp/two
> nyc npm test


> two@0.0.1 test ~/generator-express/temp/two
> NODE_ENV=test mocha --recursive test



  config
    ✓ should load

  configure express
    ✓ should load
    ✓ should return the app

  home routes
    ✓ should load

  article
    ✓ should load

  model
    ✓ should load

  app
    ✓ should load

  /
    ✓ should load
    render
Executing (default): SELECT `id`, `title`, `url`, `text`, `createdAt`, `updatedAt` FROM `Articles` AS `Article`;
GET / 200 45.629 ms - 322
      ✓ should render index (75ms)
    errors
GET /notexistant 404 8.846 ms - 252
      ✓ should handle pages which are not found


  10 passing (119ms)

---------------------|----------|----------|----------|----------|----------------|
File                 |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------|----------|----------|----------|----------|----------------|
All files            |     92.5 |    63.64 |    81.25 |     92.5 |                |
 two                 |       70 |       50 |    33.33 |       70 |                |
  app.js             |       70 |       50 |    33.33 |       70 |       15,16,20 |
 two/app/controllers |      100 |      100 |      100 |      100 |                |
  home.js            |      100 |      100 |      100 |      100 |                |
 two/app/models      |      100 |       75 |      100 |      100 |                |
  article.js         |      100 |      100 |      100 |      100 |                |
  index.js           |      100 |       75 |      100 |      100 |                |
 two/config          |    93.02 |     62.5 |       80 |    93.02 |                |
  config.js          |      100 |     87.5 |      100 |      100 |                |
  express.js         |    92.11 |     37.5 |       80 |    92.11 |       48,49,50 |
---------------------|----------|----------|----------|----------|----------------|
```